### PR TITLE
Add MongoDB connection helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copie este arquivo para `.env` e substitua os valores das variáveis conforme necessário
+MONGODB_URI=mongodb+srv://<usuario>:<senha>@cluster0.bp4nai0.mongodb.net/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Artist-world
-cuzingostoso
+
+Aplicativo front-end Vite + React.
+
+## Configurando a conexão com o MongoDB
+
+1. Copie o arquivo `.env.example` para `.env` e preencha a variável `MONGODB_URI` com sua string de conexão do MongoDB.
+2. Instale a dependência `mongodb` no projeto (``npm install mongodb``).
+3. Utilize o módulo `src/lib/mongodb.js` para iniciar a conexão no backend Node.js.

--- a/src/lib/mongodb.js
+++ b/src/lib/mongodb.js
@@ -1,0 +1,19 @@
+import { MongoClient } from 'mongodb';
+
+// URL de conexão obtida do arquivo .env
+const uri = process.env.MONGODB_URI;
+
+const client = new MongoClient(uri);
+
+export async function connectDB() {
+  try {
+    await client.connect();
+    console.log('Conectado ao MongoDB');
+    return client;
+  } catch (error) {
+    console.error('Erro ao conectar ao MongoDB:', error);
+    throw error;
+  }
+}
+
+export default client;


### PR DESCRIPTION
## Summary
- add MongoDB helper using environment variable
- document how to use MongoDB connection
- provide `.env.example`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849dacba55c832da0893add12eb0cdd